### PR TITLE
feat: CloudFront+S3で静的コンテンツを配信するConstructを追加

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,1 @@
+<h1>Hello, World!</h1>

--- a/lib/cdk_test_study-stack.ts
+++ b/lib/cdk_test_study-stack.ts
@@ -2,10 +2,15 @@ import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as s3 from 'aws-cdk-lib/aws-s3';
+// import { StaticSite } from './construct/static_site';
 
 export class CdkTestStudyStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
+
+    // new StaticSite(this, 'StaticSite', {
+    //   staticContentPath: './app',
+    // });
 
     const vpc = new ec2.Vpc(this, 'CdkTestStudyVpc', {
       maxAzs: 2,

--- a/lib/construct/static_site.ts
+++ b/lib/construct/static_site.ts
@@ -1,0 +1,44 @@
+import * as cdk from 'aws-cdk-lib';
+import {
+  RemovalPolicy,
+  Stack,
+  StackProps,
+  aws_cloudfront as cloudfront,
+  aws_cloudfront_origins as cloudfront_origins,
+  aws_s3 as s3,
+  aws_s3_deployment as s3_deployment,
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+export interface StaticSiteProps {
+  staticContentPath: string;
+}
+
+export class StaticSite extends Construct {
+  constructor(scope: Construct, id: string, props: StaticSiteProps) {
+    super(scope, id);
+
+    // 静的コンテンツを配置する S3 バケットを作成
+    const staticContentBucket = new s3.Bucket(this, 'StaticContentBucket', {
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
+    // CloudFront ディストリビューションを作成
+    const distribution = new cloudfront.Distribution(this, 'Distribution', {
+      defaultRootObject: 'index.html',
+      defaultBehavior: {
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        // S3BucketOrigin.withOriginAccessControlを使用
+        origin: cloudfront_origins.S3BucketOrigin.withOriginAccessControl(staticContentBucket)
+      },
+    });
+
+    // 静的コンテンツをS3にデプロイ
+    new s3_deployment.BucketDeployment(this, 'staticContentDeploy', {
+      sources: [s3_deployment.Source.asset(props.staticContentPath)],
+      destinationBucket: staticContentBucket,
+      distribution: distribution,
+      distributionPaths: ['/*'],
+    });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cdk_test_study",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.147.0",
+        "aws-cdk-lib": "2.156.0",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
       },
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "20.14.2",
-        "aws-cdk": "2.147.0",
+        "aws-cdk": "2.156.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.4",
         "ts-node": "^10.9.2",
@@ -52,6 +52,41 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
       "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "36.0.24",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-36.0.24.tgz",
+      "integrity": "sha512-dHyb4lvd6nbNHLVvdyxVPgwc0MyzN3VzIJnWwGJWKOIwVqL7hvU2NkQQrktY9T2MtdhzUdDFm9qluxuLRV5Cfw==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">= 18.18.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.6.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.7",
@@ -1236,9 +1271,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.147.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.147.0.tgz",
-      "integrity": "sha512-xkz07DNnpBwVeSaiV62SapLzifprC78PG/KxRZiJXg6CQEddcu9/Icvws6i8YRjDtEkvH6WmOwIFGrdkbOt7Lw==",
+      "version": "2.156.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.156.0.tgz",
+      "integrity": "sha512-f8Uk3XK1mqG1j9lP9Dj8IKVC6MOvODHZ0iQ3Ytpv3O9hDOu5qGpfksw43S20I8jsJwI/caauO8ZNTF+xPBpYpg==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -1251,9 +1286,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.147.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.147.0.tgz",
-      "integrity": "sha512-0dzUEeWxpuLeeQvqwR4Vz2ja/V0nzzgndgPdp56nc9CsghbrFtMATtno3ec5INHiJz/Mj6/NXQ5t9vrffd6Mgw==",
+      "version": "2.156.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.156.0.tgz",
+      "integrity": "sha512-iZJEWlJYGcwtHcaLVps5IjMegaka5btXcOH8hgTTjcFMFwR83KVBix6mDkhbGcLMIoIZBYBpp5t9fgG+ZuyNoA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1271,6 +1306,7 @@
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
+        "@aws-cdk/cloud-assembly-schema": "^36.0.5",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
@@ -3616,7 +3652,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "20.14.2",
-    "aws-cdk": "2.147.0",
+    "aws-cdk": "2.156.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
     "ts-node": "^10.9.2",
     "typescript": "~5.4.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.147.0",
+    "aws-cdk-lib": "2.156.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
CloudFront+S3で静的コンテンツを配信するConstructを追加
- OACのL2コンストラクトを使用するため、cdkの2.156.0以上のバージョンが必要
- S3にアップロードするディレクトリは、コンストラクトの引数で指定する